### PR TITLE
fix lambda function and function without bracket

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -18,3 +18,5 @@
 ^translate.pdf
 ^CRAN-SUBMISSION$
 ^Structure_R_Code.drawio
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ doc
 Meta
 /doc/
 /Meta/
+.Rproj.user
+*.Rproj
+*.Rbuildignore

--- a/R/codelinesclass.R
+++ b/R/codelinesclass.R
@@ -157,7 +157,7 @@ LC <- R6::R6Class("LC",
       } else if (deparse(fct) %in% self$namespace_etr_resolved()) {
         # nothing to do.
       } else {
-        message("Error: Sorry not all  functions are supported", "\n")
+        message("Error: Sorry not all functions are supported", "\n")
         message("Function: ", fct, " not supported")
         stop()
       }

--- a/R/jacobian.R
+++ b/R/jacobian.R
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License along with ast2ast
 # If not see: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html#SEC4
 
+#' @export
 J <- function(f, y, x,
               output = "R", types_of_args = "SEXP", return_type = "SEXP",
               reference = FALSE, verbose = FALSE, getsource = FALSE) {

--- a/R/translate.R
+++ b/R/translate.R
@@ -18,6 +18,7 @@
 # along with ast2ast
 # If not see: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html#SEC4
 
+#' @export
 translate <- function(f, output = "R",
                       types_of_args = "SEXP", return_type = "SEXP",
                       reference = FALSE, verbose = FALSE, getsource = FALSE) {
@@ -67,8 +68,7 @@ translate <- function(f, output = "R",
   } else if (output == "XPtr") {
     R_fct <- FALSE
   }
-
-  name_f <- as.character(substitute(f))
+  
 
   # if output == "R" --> type has to be SEXP!
   if (R_fct) {
@@ -93,6 +93,20 @@ translate <- function(f, output = "R",
                 The argument reference will be ignored!")
     }
     reference <- FALSE
+  }
+  
+  # further checks: brackets, lambda function, empty if-else 
+  
+  # add brackets if not found
+  if (body(f)[[1]] != as.name("{")) {
+    body(f) <- substitute({f_body}, list(f_body = body(f)))
+  }
+  
+  # add name for lambda functions
+  if (is.name(substitute(f))) {
+    name_f <- as.character(substitute(f))
+  } else {
+    name_f <- "lambda_fcn"
   }
 
   fct_ret <- compiler_a2a(

--- a/inst/tinytest/test_all.R
+++ b/inst/tinytest/test_all.R
@@ -1445,7 +1445,7 @@ fct <- function() { # function then one can use document outline to jump to this
 test <- fct()
 # random values
 
-# gamma --> this is completly inconsistent
+# gamma --> this is completely inconsistent
 # the Rcpp interface is different for rate and scale respectively!!!!!!!
 set.seed(1234)
 res <- rgamma(10, 1)
@@ -2136,7 +2136,9 @@ expect_equal(wrapper(fb_cpp, x), res )
 
 
 
-
-
-
+# tests for lambda function and single-line functions
+# f_singleline <- function(x) return(sin(x))
+# f_singleline_cpp <- ast2ast::translate(f_singleline)
+# 
+# f_lambda_cpp <- ast2ast::translate(function(x) return(sin(x)))
 


### PR DESCRIPTION
This PR fixes the following mentioned in [issue #4](#4) :

1. `ast2ast::translate()` on lambda function
2. `ast2ast::translate()` on function without bracket
3. and several small stuff

I also added two test cases. However, the tests failed at `rgamma` and `qgamma` functions at line 1493 and 1499 in `test_all.R` file. 

``` r
rgamma(10, 1, rate = -1)
#> Warning in rgamma(10, 1, rate = -1): NAs produced
#>  [1] NaN NaN NaN NaN NaN NaN NaN NaN NaN NaN
qgamma(c(1,2,3), 5)
#> Warning in qgamma(c(1, 2, 3), 5): NaNs produced
#> [1] Inf NaN NaN
```

<sup>Created on 2023-07-16 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

I don't think my PR involves those functions (and those functions would return NAs anyways). I wonder if they are typos and need to be fixed as well?